### PR TITLE
Adjust Cropping for GOES15 Satellite

### DIFF
--- a/cfg/satellites.json
+++ b/cfg/satellites.json
@@ -73,9 +73,9 @@
         "limit":
         {
            "left": 67,
-           "right": 2750,
+           "right": 2645,
            "top": 70,
-           "bottom": 2750
+           "bottom": 2632
         },
         "resolution_str":
         {


### PR DESCRIPTION
It looks like the image size for GOES 15 was decreased slightly.  This meant the old crop numbers were actually increasing the image size adding black space, so when it was projected it looked odd in the southern hemisphere.

These adjustments work for me.  I apologize for posting all sorts of random unhelpful information on the issue thread.

Fixes #10 